### PR TITLE
imx6qdl-var-som.dtsi - fix PWM naming

### DIFF
--- a/arch/arm/boot/dts/imx6qdl-var-som.dtsi
+++ b/arch/arm/boot/dts/imx6qdl-var-som.dtsi
@@ -503,7 +503,7 @@
 			>;
 		};
 
-		pinctrl_pwm1_1: pwm1grp {
+		pinctrl_pwm2_1: pwm2grp {
 			fsl,pins = <
 				MX6QDL_PAD_DISP0_DAT9__PWM2_OUT		0x1b0b1
 			>;
@@ -700,7 +700,7 @@
 
 &pwm2 {
 	pinctrl-names = "default";
-	pinctrl-0 = <&pinctrl_pwm1_1>;
+	pinctrl-0 = <&pinctrl_pwm2_1>;
 	status = "okay";
 };
 


### PR DESCRIPTION
According to the i.MX6 datasheet this is the second PWM, not the first one.
